### PR TITLE
Update mysql.schema

### DIFF
--- a/src/os_dbd/mysql.schema
+++ b/src/os_dbd/mysql.schema
@@ -1,5 +1,4 @@
 # @(#) $Id: ./src/os_dbd/mysql.schema, 2011/09/08 dcid Exp $
- */
 #
 # Copyright (C) 2009 Trend Micro Inc.
 # All rights reserved.


### PR DESCRIPTION
Removed character  */ on comments. The follow error was displayed during ossec database configuration.

ERROR 1064 (42000) at line 2: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '*/
